### PR TITLE
add role and policy for S3 to RDS (IOW-561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - New repository
+- Add role and policy for S3->RDS data transfer

--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 [![codecov](https://codecov.io/gh/usgs/aqts-capture-trigger/branch/master/graph/badge.svg)](https://codecov.io/gh/usgs/aqts-capture-trigger)
 
 AWS Lambda function designed to trigger the AQTS Capture State Machine.
+
+## Updating the S3 to RDS Role
+Any time you deploy this service, you need to make sure the S3 to RDS Role is assigned to the RDS Cluster.
+Right now, this is a manual step:
+
+RDS->Databases->nwcapture-<tier>
+
+Add IAM Roles to this cluster: aqts-capture-trigger-<tier>-NwCaptureS3ToRDS-Transfer<Random String>
+Feature: s3Import

--- a/serverless.yml
+++ b/serverless.yml
@@ -79,7 +79,7 @@ resources:
                     - s3:ListBucketMultipartUploads
                     - s3:PutObject
                   Resource:
-                    - arn:aws:s3:*:*:${self:custom.bucketName}
+                    - arn:aws:s3:*:${self:custom.bucketName}
         PermissionsBoundary: arn:aws:iam::${self:custom.accountNumber}:policy/csr-Developer-Permissions-Boundary
     snsTopic:
       Type: AWS::SNS::Topic

--- a/serverless.yml
+++ b/serverless.yml
@@ -81,8 +81,7 @@ resources:
                     - s3:PutObject
                   Resource:
                     - arn:aws:s3:*:*:${self:custom.bucketName}
-        PermissionBoundary: arn:aws:iam::${self:custom.accountNumber}:policy/csr-Developer-Permissions-Boundary
-
+        PermissionsBoundary: arn:aws:iam::${self:custom.accountNumber}:policy/csr-Developer-Permissions-Boundary
     snsTopic:
       Type: AWS::SNS::Topic
       Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -71,6 +71,7 @@ resources:
               Version: '2012-10-17'
               Statement:
                 - Effect: Allow
+                  Principal: '*'
                   Action:
                     - s3:AbortMultipartUpload
                     - s3:GetBucketLocation
@@ -79,11 +80,7 @@ resources:
                     - s3:ListBucketMultipartUploads
                     - s3:PutObject
                   Resource:
-                    - { Fn::GetAtt: [ "${self:custom.bucketName}", Arn ] }
-                    - Fn::Join:
-                        - ""
-                        - - { Fn::GetAtt: [ "${self:custom.bucketName}", Arn ] }
-                          - "/*"
+                    - arn:aws:s3:*:*:${self:custom.bucketName}
 
     snsTopic:
       Type: AWS::SNS::Topic

--- a/serverless.yml
+++ b/serverless.yml
@@ -51,6 +51,39 @@ functions:
 
 resources:
   Resources:
+    NwCaptureS3ToRDSTransferPolicy:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                Service:
+                  - rds.amazonaws.com
+              Action:
+                - sts:AssumeRole
+        Path: "/"
+        Policies:
+          - PolicyName: NwCaptureS3ToRDSTransferPolicy
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action:
+                    - s3:AbortMultipartUpload
+                    - s3:GetBucketLocation
+                    - s3:GetObject
+                    - s3:ListBucket
+                    - s3:ListBucketMultipartUploads
+                    - s3:PutObject
+                  Resource:
+                    - { Fn::GetAtt: [ iow-retriever-capture-${self:custom.environments.${self:provider.stage}}, Arn ] }
+                    - Fn::Join:
+                        - ""
+                        - - { Fn::GetAtt: [ iow-retriever-capture-${self:custom.environments.${self:provider.stage}}, Arn ] }
+                          - "/*"
+
     snsTopic:
       Type: AWS::SNS::Topic
       Properties:

--- a/serverless.yml
+++ b/serverless.yml
@@ -71,7 +71,6 @@ resources:
               Version: '2012-10-17'
               Statement:
                 - Effect: Allow
-                  Principal: '*'
                   Action:
                     - s3:AbortMultipartUpload
                     - s3:GetBucketLocation

--- a/serverless.yml
+++ b/serverless.yml
@@ -79,10 +79,10 @@ resources:
                     - s3:ListBucketMultipartUploads
                     - s3:PutObject
                   Resource:
-                    - { Fn::GetAtt: [ ${self:custom.bucketName}, Arn ] }
+                    - { Fn::GetAtt: [ "${self:custom.bucketName}", Arn ] }
                     - Fn::Join:
                         - ""
-                        - - { Fn::GetAtt: [ ${self:custom.bucketName}, Arn ] }
+                        - - { Fn::GetAtt: [ "${self:custom.bucketName}", Arn ] }
                           - "/*"
 
     snsTopic:

--- a/serverless.yml
+++ b/serverless.yml
@@ -59,7 +59,7 @@ resources:
           Version: '2012-10-17'
           Statement:
             - Effect: Allow
-              Principal:
+              Principal: '*'
                 Service:
                   - rds.amazonaws.com
               Action:

--- a/serverless.yml
+++ b/serverless.yml
@@ -59,11 +59,13 @@ resources:
           Version: '2012-10-17'
           Statement:
             - Effect: Allow
-              Principal: '*'
-              Service:
-                - rds.amazonaws.com
+              Principal:
+                Service:
+                  - rds.amazonaws.com
               Action:
                 - sts:AssumeRole
+              Resource:
+                - Sub! arn:aws:iam::${self:custom.accountNumber}:policy/csr-Developer-Permissions-Boundary
         Path: "/"
         Policies:
           - PolicyName: NwCaptureS3ToRDSTransferPolicy

--- a/serverless.yml
+++ b/serverless.yml
@@ -60,8 +60,8 @@ resources:
           Statement:
             - Effect: Allow
               Principal: '*'
-                Service:
-                  - rds.amazonaws.com
+              Service:
+                - rds.amazonaws.com
               Action:
                 - sts:AssumeRole
         Path: "/"

--- a/serverless.yml
+++ b/serverless.yml
@@ -64,8 +64,6 @@ resources:
                   - rds.amazonaws.com
               Action:
                 - sts:AssumeRole
-              Resource:
-                - Sub! arn:aws:iam::${self:custom.accountNumber}:policy/csr-Developer-Permissions-Boundary
         Path: "/"
         Policies:
           - PolicyName: NwCaptureS3ToRDSTransferPolicy
@@ -83,6 +81,7 @@ resources:
                     - s3:PutObject
                   Resource:
                     - arn:aws:s3:*:*:${self:custom.bucketName}
+        PermissionBoundary: arn:aws:iam::${self:custom.accountNumber}:policy/csr-Developer-Permissions-Boundary
 
     snsTopic:
       Type: AWS::SNS::Topic

--- a/serverless.yml
+++ b/serverless.yml
@@ -71,6 +71,7 @@ resources:
               Version: '2012-10-17'
               Statement:
                 - Effect: Allow
+                  Principal: '*'
                   Action:
                     - s3:AbortMultipartUpload
                     - s3:GetBucketLocation
@@ -79,7 +80,8 @@ resources:
                     - s3:ListBucketMultipartUploads
                     - s3:PutObject
                   Resource:
-                    - arn:aws:s3:*:${self:custom.bucketName}
+                    - arn:aws:s3:::${self:custom.bucketName}
+                    - arn:aws:s3:::${self:custom.bucketName}/*
         PermissionsBoundary: arn:aws:iam::${self:custom.accountNumber}:policy/csr-Developer-Permissions-Boundary
     snsTopic:
       Type: AWS::SNS::Topic

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,6 +19,7 @@ provider:
     commitIdentifier: ${git:sha1}
 
 custom:
+  bucketName: iow-retriever-capture-${self:custom.environments.${self:provider.stage}}
   exportGitVariables: false
   accountNumber: ${ssm:/iow/aws/accountNumber}
   vpc:
@@ -78,10 +79,10 @@ resources:
                     - s3:ListBucketMultipartUploads
                     - s3:PutObject
                   Resource:
-                    - { Fn::GetAtt: [ iow-retriever-capture-${self:custom.environments.${self:provider.stage}}, Arn ] }
+                    - { Fn::GetAtt: [ ${self:custom.bucketName}, Arn ] }
                     - Fn::Join:
                         - ""
-                        - - { Fn::GetAtt: [ iow-retriever-capture-${self:custom.environments.${self:provider.stage}}, Arn ] }
+                        - - { Fn::GetAtt: [ ${self:custom.bucketName}, Arn ] }
                           - "/*"
 
     snsTopic:
@@ -131,7 +132,7 @@ resources:
         - triggerQueue
         - triggerQueuePolicy
       Properties:
-        BucketName: iow-retriever-capture-${self:custom.environments.${self:provider.stage}}
+        BucketName: ${self:custom.bucketName}
         AccessControl: Private
         LifecycleConfiguration:
           Rules:

--- a/trigger/handler.py
+++ b/trigger/handler.py
@@ -49,14 +49,9 @@ def lambda_handler(event, context):
             else:
                 # handle things are coming through for the first time (i.e. they haven't failed before)
                 for s3_record in s3_record_list:
-                    s3_object_size = s3_record['s3']['object']['size']
-                    if int(s3_object_size) < s3_object_size_limit:
-                        raw_payload = {'Record': s3_record}
-                        payload = json.dumps(raw_payload)
-                        process_individual_payload(payload)
-                    # ignore giant s3 files for now
-                    else:
-                        logger.info(f'Omitted {s3_record} because it exceeded the set file size limit for loading.')
+                    raw_payload = {'Record': s3_record}
+                    payload = json.dumps(raw_payload)
+                    process_individual_payload(payload)
         else:
             raise TypeError(f'Unsupported Event Source Found: {event_source}')
     return json.loads(json.dumps({'Responses': responses}, default=serialize_datetime))


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Add role and policy for S3 to RDS
-----------
Create the role and policy necessary for transfering data from S3 to RDS.
https://internal.cida.usgs.gov/jira/browse/IOW-561

Description
-----------
Right now I'm not seeing a way to actually assign the new role to RDS in serverless.yml, since RDS is created in another stack.  It is trivial to assign the policy in the console and a one-time thing, so ... maybe do the assign programmatically when we move to Aurora Serverless.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
