### PR TITLE
IOW-758 restore object size limit to capture trigger

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -62,6 +62,7 @@ functions:
     environment:
       STATE_MACHINE_ARN: arn:aws:states:${self:provider.region}:#{AWS::AccountId}:stateMachine:aqts-capture-state-machine-${self:provider.stage}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
+      OBJECT_SIZE_LIMIT: 150000000
       LOG_LEVEL: ERROR
 
 resources:

--- a/trigger/handler.py
+++ b/trigger/handler.py
@@ -49,9 +49,14 @@ def lambda_handler(event, context):
             else:
                 # handle things are coming through for the first time (i.e. they haven't failed before)
                 for s3_record in s3_record_list:
-                    raw_payload = {'Record': s3_record}
-                    payload = json.dumps(raw_payload)
-                    process_individual_payload(payload)
+                    s3_object_size = s3_record['s3']['object']['size']
+                    if int(s3_object_size) < s3_object_size_limit:
+                        raw_payload = {'Record': s3_record}
+                        payload = json.dumps(raw_payload)
+                        process_individual_payload(payload)
+                    # ignore giant s3 files for now
+                    else:
+                        logger.info(f'Omitted {s3_record} because it exceeded the set file size limit for loading.')
         else:
             raise TypeError(f'Unsupported Event Source Found: {event_source}')
     return json.loads(json.dumps({'Responses': responses}, default=serialize_datetime))


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
Restore object size limit.

Description
-----------
The object size limit was removed when we attempted to use the aws_s3 extension to handle large objects.  Ultimately, the aws_s3 extension did not do what we needed it to do, but the object size limit was not restored.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
